### PR TITLE
Added missing argument for mapDispatchToProps

### DIFF
--- a/src/connectModule/connectModules.js
+++ b/src/connectModule/connectModules.js
@@ -73,7 +73,7 @@ export default function connectModules(mapStateToProps, modules) {
         this.lastRenderedProps = null;
         const sourceSelector = createFinalPropsSelector(
           createMapStateToProps(mapStateToProps),
-          props => mapDispatchToProps(this.store.dispatch, props));
+          (dispatch, props) => mapDispatchToProps(this.store.dispatch, props));
 
         const memoizeOwn = memoizeProps();
         const memoizeFinal = memoizeProps();


### PR DESCRIPTION
The parent's `dispatch` function wasn't being passed appropriately to nested components.
Added the missing `dispatch` argument in order to pass the correct `props` object.

I'm not seeing the dispatch being set in `createFinalPropsSelector` which is why i didn't modify `this.store.dispatch` to `dispatch` for now.