### PR TITLE
Drop `babel`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
   },
   "devDependencies": {
     "app-root-path": "^1.0.0",
-    "babel": "^6.5.2",
     "babel-cli": "^6.6.5",
     "babel-core": "^6.7.2",
     "babel-eslint": "^6.0.4",


### PR DESCRIPTION
It isn't used and it gives a warning on `yarn install`.